### PR TITLE
trace: skip NULL address in add_print_address

### DIFF
--- a/trace.c
+++ b/trace.c
@@ -2226,6 +2226,9 @@ static int add_print_address(long address)
 	size_t len;
 	int i;
 
+	if (!address)
+		return 0;
+
 	len = read_string(address, string, sizeof(string));
 	if (!len)
 		return -1;


### PR DESCRIPTION
If trace_printk() uses a format that is not constant, corresponding entry in __trace_printk_fmt section will set to NULL.
This NULL address cause add_print_address return -1, finally, trace cmd cannot work.
Just skip NULL address.

Related kernel commit:
3debb0a9ddb1 (tracing: Fix trace_printk() to print when not using bprintk())